### PR TITLE
Allow the pool connection to use SSL.

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -304,8 +304,8 @@ class Hub(QObject):
     def close_addpool_dialog(self):
         self.add_pool_dialog.close()
     
-    @Slot(str, str, str, str, str, str)
-    def add_edit_pool(self, pool_id, pool_display_name, pool_url, pool_username, pool_password, pool_algo):
+    @Slot(str, str, str, str, str, str, bool)
+    def add_edit_pool(self, pool_id, pool_display_name, pool_url, pool_username, pool_password, pool_algo, pool_ssl):
         
         if not pool_display_name.strip():
             QMessageBox.warning(self.add_pool_dialog,'Add/Edit Pool Error', "Pool Name is required.")
@@ -359,6 +359,7 @@ class Hub(QObject):
                 'num_cpus': get_num_cpus(),
                 'priority_level': 'normal',
                 'is_hidden': False,
+                'ssl_enabled': pool_ssl,
             }
              
             self.pools.add_pool(pool_info)
@@ -403,6 +404,11 @@ class Hub(QObject):
                     pool_info['password'] = password
                     need_restart_mining = True
                     
+                if  'ssl_enabled' in pool_info and pool_info['ssl_enabled'] != pool_ssl:
+                    need_restart_mining = True
+                pool_info['ssl_enabled'] = pool_ssl
+
+
                 pool_info['is_hidden'] = False
                 
                 _pool_info = {
@@ -442,6 +448,11 @@ class Hub(QObject):
                 'password': pool_info['password'],
                 'is_fixed': pool_info['is_fixed'],
             }
+
+            if 'ssl_enabled' in pool_info:
+                _pool_info['ssl_enabled'] = pool_info['ssl_enabled']
+            else:
+                _pool_info['ssl_enabled'] = False
             self.on_edit_pool_event.emit(json.dumps(_pool_info))
             self.add_pool_dialog.exec_()
             

--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -40,6 +40,7 @@ class Pools():
              "url": "stratum+tcp://pool.sumokoin.com:3333", 
              "num_cpus": 0, 
              "algo": "Cryptonight", 
+             "ssl_enabled": False,
              "is_fixed": True
           }
         ]
@@ -55,6 +56,7 @@ class Pools():
         p['is_mining'] = p['is_mining'] if 'is_mining' in p else False
         p['is_hidden'] = p['is_hidden'] if 'is_hidden' in p else False
         p['is_fixed'] = p['is_fixed'] if 'is_fixed' in p else False
+        p['ssl_enabled'] = p['ssl_enabled'] if 'ssl_enabled' in p else False
         p['num_cpus'] = p['num_cpus'] if 'num_cpus' in p else \
                                 (CPU_COUNT - 1 if CPU_COUNT > 1 else CPU_COUNT)
         p['priority_level'] = p['priority_level'] if 'priority_level' in p else 'normal'    
@@ -108,6 +110,7 @@ class Pools():
                 'is_hidden': p['is_hidden'],
                 'is_fixed': p['is_fixed'],
                 'num_cpus': p['num_cpus'],
+                'ssl_enabled': p['ssl_enabled'],
                 'priority_level': p['priority_level'],
             }
             _pools.append(_p)

--- a/html/addpool.py
+++ b/html/addpool.py
@@ -43,6 +43,7 @@ html = """
                     $('#pool_url').val(pool_info['url']);
                     $('#pool_username').val(pool_info['username']);
                     $('#pool_password').val(pool_info['password']);
+                    $('#pool_ssl').prop('checked', pool_info['ssl_enabled']);
                     
                     if(pool_info['is_fixed']){
                         $('#pool_algo').prop('disabled', true);
@@ -59,8 +60,9 @@ html = """
                 var pool_username = $('#pool_username').val();
                 var pool_password = $('#pool_password').val();
                 var pool_algo = $('#pool_algo').val();
+                var pool_ssl = $('#pool_ssl').is(':checked');
                 
-                app_hub.add_edit_pool(pool_id, pool_display_name, pool_url, pool_username, pool_password, pool_algo);
+                app_hub.add_edit_pool(pool_id, pool_display_name, pool_url, pool_username, pool_password, pool_algo, pool_ssl);
                 
                 return false;
             }
@@ -164,6 +166,12 @@ html = """
                         <label for="pool_url" class="col-xs-3 control-label">URL/Port <sup>*</sup></label>
                         <div class="col-xs-9">
                             <input type="text" id="pool_url" placeholder="e.g. pool.sumokoin.com:3333 (required)" maxlength="512">
+                        </div>
+                    </div>
+                     <div class="form-group">
+                        <label for="pool_url" class="col-xs-3 control-label">Enable SSL <sup>*</sup></label>
+                        <div class="col-xs-9">
+                            <input type="checkbox" id="pool_ssl">
                         </div>
                     </div>
                      <div class="form-group">

--- a/miner/miner.py
+++ b/miner/miner.py
@@ -10,6 +10,7 @@ import sys, psutil
 
 import json, socket, struct
 import errno 
+import ssl
 import threading, time, urlparse, random, platform
 from multiprocessing import Process, Event, cpu_count
 #from threading import Timer
@@ -412,6 +413,9 @@ class MinerRPC(SimpleJsonRpcClient):
                     self._my_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     self._sock_keep_alive()
               
+            if 'ssl_enabled' in self._pool_info and self._pool_info['ssl_enabled']:
+                self._my_sock = ssl.wrap_socket(self._my_sock)
+
             try:
                 self._my_sock.connect((hostname, port))
                 self.connect(self._my_sock)


### PR DESCRIPTION
This updates the UI and all the pool save and loading mechanism so
support an 'ssl_enabled' flag for a pool. When the flag (a checkbox in
the UI) is set to True; SSL will be used for the connection.

I tested this on Linux and everything seems to work fine but I'm not sure is p
how this will work on Windows and Mac's. It needs to be tested and depends on 
OpenSSL being available in the python distribution that is packaged in the binary.